### PR TITLE
QtSolutions: Fix build with Qt 5.5.1.

### DIFF
--- a/src/QtSolutions/qtlocalpeer.cpp
+++ b/src/QtSolutions/qtlocalpeer.cpp
@@ -40,6 +40,7 @@
 
 #include "qtlocalpeer.h"
 #include <QtCore/QCoreApplication>
+#include <QtCore/QDataStream>
 #include <QtCore/QTime>
 #include <QRegularExpression>
 


### PR DESCRIPTION
Import commit ad9bc4600 to the qt-solutions git repository:
  QtSingleApplication: Fix build with Qt 5.5 due to the QDataStream
  include cleanup.

This fixes the following error:

```
src/QtSolutions/qtlocalpeer.cpp:159:17: error: variable has incomplete type 'QDataStream'
    QDataStream ds(&socket);
                ^
/usr/local/include/qt5/QtCore/qglobal.h:570:7: note: forward declaration of 'QDataStream'
class QDataStream;
      ^
src/QtSolutions/qtlocalpeer.cpp:179:17: error: variable has incomplete type 'QDataStream'
    QDataStream ds(socket);
                ^
/usr/local/include/qt5/QtCore/qglobal.h:570:7: note: forward declaration of 'QDataStream'
class QDataStream;
      ^
```
