### PR TITLE
Fix build with Qt 5.11

### DIFF
--- a/src/transactiondialog.cpp
+++ b/src/transactiondialog.cpp
@@ -24,6 +24,7 @@
 
 #include <QMessageBox>
 #include <QPushButton>
+#include <QRegularExpression>
 #include <QDialog>
 #include <QCloseEvent>
 


### PR DESCRIPTION
Add missing header for Qt 5.11

c++ -c -O2 -pipe -fstack-protector -fno-strict-aliasing -std=c++11 -std=gnu++11 -Wall -W -pthread -fPIC -DOCTOPKG_EXTENSIONS -DQT_QUICKWIDGETS_LIB -DQT_WIDGETS_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_XML_LIB -DQT_DBUS_LIB -DQT_CORE_LIB -I. -I/usr/local/include -I/usr/local/include/qt5 -I/usr/local/include/qt5/QtQuickWidgets -I/usr/local/include/qt5/QtWidgets -I/usr/local/include/qt5/QtQuick -I/usr/local/include/qt5/QtGui -I/usr/local/include/qt5/QtQml -I/usr/local/include/qt5/QtNetwork -I/usr/local/include/qt5/QtXml -I/usr/local/include/qt5/QtDBus -I/usr/local/include/qt5/QtCore -Ibuild -I/usr/local/include -I/usr/local/include/libdrm -Ibuild -I/usr/local/include -I/usr/local/lib/qt5/mkspecs/freebsd-clang -o build/moc_utils.o build/moc_utils.cpp
--- build/transactiondialog.o ---
src/transactiondialog.cpp:78:29: error: 'QRegularExpression' is an incomplete type
  if (detailedtext.contains(QRegularExpression("pacman-[0-9]+")))
                            ^
/usr/local/include/qt5/QtCore/qstring.h:83:7: note: forward declaration of 'QRegularExpression'
class QRegularExpression;
      ^
1 error generated.
*** [build/transactiondialog.o] Error code 1